### PR TITLE
Manifest fails is ~/Library/PreferencePanes path not already exist

### DIFF
--- a/lib/puppet/provider/prefpane/download.rb
+++ b/lib/puppet/provider/prefpane/download.rb
@@ -80,7 +80,7 @@ Puppet::Type.type(:prefpane).provide(:download) do
     path_parts = [(mount || temp_dir), (@resource[:path] || '**'), "#{@resource[:name]}.prefPane"]
     prefpane_path = Dir[File.join(*path_parts.compact)][0]
     target = self.class.prefpanes_path
-    if Dir.exists? target then
+    if !Dir.exists? target then
       Dir.mkdir target
     end
     cp "-a", prefpane_path, self.class.prefpanes_path

--- a/lib/puppet/provider/prefpane/download.rb
+++ b/lib/puppet/provider/prefpane/download.rb
@@ -79,6 +79,7 @@ Puppet::Type.type(:prefpane).provide(:download) do
     # copy into PreferencePanes
     path_parts = [(mount || temp_dir), (@resource[:path] || '**'), "#{@resource[:name]}.prefPane"]
     prefpane_path = Dir[File.join(*path_parts.compact)][0]
+    mkdir "-p", self.class.prefpanes_path
     cp "-a", prefpane_path, self.class.prefpanes_path
 
     # ensure ownership by user

--- a/lib/puppet/provider/prefpane/download.rb
+++ b/lib/puppet/provider/prefpane/download.rb
@@ -79,7 +79,10 @@ Puppet::Type.type(:prefpane).provide(:download) do
     # copy into PreferencePanes
     path_parts = [(mount || temp_dir), (@resource[:path] || '**'), "#{@resource[:name]}.prefPane"]
     prefpane_path = Dir[File.join(*path_parts.compact)][0]
-    mkdir "-p", self.class.prefpanes_path
+    target = self.class.prefpanes_path
+    if Dir.exists? target then
+      Dir.mkdir target
+    end
     cp "-a", prefpane_path, self.class.prefpanes_path
 
     # ensure ownership by user


### PR DESCRIPTION
Added a bit of logic to check if this directory exists.  If it doesn't, we will now create it before attempting to copy the `.prefPane` file
